### PR TITLE
Fix missing include for gcc 13

### DIFF
--- a/altv_sdk/src/shared.h
+++ b/altv_sdk/src/shared.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "../cpp-sdk/SDK.h"
 #include "../cpp-sdk/events/CMetaDataChangeEvent.h"
 #include <string>


### PR DESCRIPTION
This change fixes the altv_internal_sdk build on systems shipping GCC 13.

```
warning: src/../cpp-sdk/deps/alt-config/alt-config.h:157:30: error: expected ')' before 'val'
warning:   157 |                 Node(uint64_t val) : Node(static_cast<double>(val)) { }
warning:       |                     ~        ^~~~
```